### PR TITLE
feat: Add HTTPS support with Nginx reverse proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,11 @@ htmlcov/
 .env.development.local
 .env.test.local
 .env.production.local
+
+# SSL Certificates (never commit!)
+nginx/ssl/*.crt
+nginx/ssl/*.key
+nginx/ssl/*.pem
+
+# Production environment files
+.env.prod

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,8 +27,9 @@ services:
       target: production
     container_name: mintroai-backend
     restart: unless-stopped
-    ports:
-      - "8080:8080"
+    # Remove external port exposure (only accessible via Nginx)
+    expose:
+      - "8080"
     environment:
       # Redis connection
       - REDIS_URL=redis://redis:6379/0
@@ -71,6 +72,29 @@ services:
       retries: 3
       start_period: 40s
     
+    networks:
+      - mintroai-network
+
+  # Nginx reverse proxy with SSL
+  nginx:
+    image: nginx:1.25-alpine
+    container_name: mintroai-nginx
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/ssl:/etc/nginx/ssl:ro
+      - ./logs/nginx:/var/log/nginx
+    depends_on:
+      app:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost/api/v1/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
     networks:
       - mintroai-network
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,143 @@
+events {
+    worker_connections 1024;
+}
+
+http {
+    # Basic Settings
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 65;
+    types_hash_max_size 2048;
+    client_max_body_size 10M;
+
+    # MIME Types
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    # Logging
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+    
+    access_log /var/log/nginx/access.log main;
+    error_log /var/log/nginx/error.log warn;
+
+    # Gzip Compression
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 10240;
+    gzip_proxied expired no-cache no-store private must-revalidate auth;
+    gzip_types text/plain text/css text/xml text/javascript application/javascript application/xml+rss application/json;
+
+    # Rate Limiting
+    limit_req_zone $binary_remote_addr zone=api:10m rate=10r/s;
+    limit_req_zone $binary_remote_addr zone=auth:10m rate=5r/s;
+
+    # Security Headers
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+    # Upstream Backend
+    upstream mintroai_backend {
+        server app:8080;
+        keepalive 32;
+    }
+
+    # HTTP Server (Redirect to HTTPS)
+    server {
+        listen 80;
+        server_name _;
+        
+        # Health check endpoint (allow HTTP for Docker health checks)
+        location /api/v1/health {
+            proxy_pass http://mintroai_backend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+        
+        # Redirect all other traffic to HTTPS
+        location / {
+            return 301 https://$host$request_uri;
+        }
+    }
+
+    # HTTPS Server
+    server {
+        listen 443 ssl http2;
+        server_name _;
+
+        # SSL Configuration
+        ssl_certificate /etc/nginx/ssl/server.crt;
+        ssl_certificate_key /etc/nginx/ssl/server.key;
+        
+        # Modern SSL Configuration
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384;
+        ssl_prefer_server_ciphers off;
+        ssl_session_cache shared:SSL:10m;
+        ssl_session_timeout 10m;
+
+        # HSTS (HTTP Strict Transport Security)
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
+        # API Endpoints
+        location /api/ {
+            # Rate limiting for API endpoints
+            limit_req zone=api burst=20 nodelay;
+            
+            proxy_pass http://mintroai_backend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto https;
+            proxy_set_header X-Forwarded-Port 443;
+            
+            # WebSocket support
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            
+            # Timeouts
+            proxy_connect_timeout 30s;
+            proxy_send_timeout 30s;
+            proxy_read_timeout 30s;
+        }
+
+        # Auth endpoints with stricter rate limiting
+        location /api/v1/auth/ {
+            limit_req zone=auth burst=10 nodelay;
+            
+            proxy_pass http://mintroai_backend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto https;
+            proxy_set_header X-Forwarded-Port 443;
+        }
+
+        # Health and metrics (no rate limiting)
+        location ~ ^/api/v1/(health|metrics)$ {
+            proxy_pass http://mintroai_backend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto https;
+        }
+
+        # Block common attack patterns
+        location ~ /\. {
+            deny all;
+            access_log off;
+            log_not_found off;
+        }
+        
+        location ~ \.(htaccess|htpasswd|ini|log|sh|sql|conf)$ {
+            deny all;
+        }
+    }
+}

--- a/nginx/ssl/README.md
+++ b/nginx/ssl/README.md
@@ -1,0 +1,44 @@
+# SSL Certificate Setup
+
+Place your SSL certificate files in this directory:
+
+## Required Files:
+- `server.crt` - SSL certificate file
+- `server.key` - Private key file
+
+## Quick Setup Options:
+
+### 1. Self-Signed Certificate (Development/Testing)
+```bash
+# Generate self-signed cert (valid for 365 days)
+openssl req -x509 -newkey rsa:2048 -keyout server.key -out server.crt -days 365 -nodes -subj "/C=US/ST=State/L=City/O=MintroAI/CN=localhost"
+
+# Set permissions
+chmod 600 server.key
+chmod 644 server.crt
+```
+
+### 2. Let's Encrypt Certificate (Production)
+```bash
+# Install certbot first, then:
+sudo certbot certonly --standalone -d your-domain.com
+
+# Copy to project
+sudo cp /etc/letsencrypt/live/your-domain.com/fullchain.pem server.crt
+sudo cp /etc/letsencrypt/live/your-domain.com/privkey.pem server.key
+sudo chmod 644 server.crt
+sudo chmod 600 server.key
+```
+
+### 3. Existing Certificate
+Just copy your existing certificate files to this directory with the correct names.
+
+## After Adding Certificates:
+```bash
+# Restart the services
+docker-compose down
+docker-compose up -d
+
+# Test HTTPS
+curl -k https://localhost/api/v1/health
+```


### PR DESCRIPTION
- Add Nginx configuration with SSL termination and security headers
- Update docker-compose.yml to include Nginx service with HTTPS (ports 80/443)
- Remove direct app port exposure (8080) for security
- Add rate limiting: API (10 req/s), Auth (5 req/s)
- Include SSL setup documentation in nginx/ssl/README.md
- Update .gitignore to exclude SSL certificates and production secrets
- Enable HTTP to HTTPS redirect and modern TLS configuration

Production Ready: Deploy with SSL certificates for secure HTTPS access